### PR TITLE
Provide a .NET Standard 2.0 build of dotnet-trees

### DIFF
--- a/TunnelVisionLabs.Collections.Trees.Experimental/TunnelVisionLabs.Collections.Trees.Experimental.csproj
+++ b/TunnelVisionLabs.Collections.Trees.Experimental/TunnelVisionLabs.Collections.Trees.Experimental.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/TunnelVisionLabs.Collections.Trees/ExcludeFromCodeCoverageAttribute.cs
+++ b/TunnelVisionLabs.Collections.Trees/ExcludeFromCodeCoverageAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if !NET45
+#if NETSTANDARD1_1
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/TunnelVisionLabs.Collections.Trees/TunnelVisionLabs.Collections.Trees.csproj
+++ b/TunnelVisionLabs.Collections.Trees/TunnelVisionLabs.Collections.Trees.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
The .NET Standard 1.3 build is removed at the same time since it isn't providing anything over the .NET Standard 1.1 build.