### PR TITLE
Fix ImmutableTreeList<T>.Builder.ToImmutable caching

### DIFF
--- a/TunnelVisionLabs.Collections.Trees.Experimental/Immutable/ImmutableTreeList`1+Builder.cs
+++ b/TunnelVisionLabs.Collections.Trees.Experimental/Immutable/ImmutableTreeList`1+Builder.cs
@@ -13,11 +13,13 @@ namespace TunnelVisionLabs.Collections.Trees.Immutable
     {
         public sealed class Builder : IList<T>, IReadOnlyList<T>, IList
         {
+            private ImmutableTreeList<T> _immutableList;
             private Node _root;
             private int _version;
 
             internal Builder(ImmutableTreeList<T> list)
             {
+                _immutableList = list;
                 _root = list._root;
             }
 
@@ -387,7 +389,11 @@ namespace TunnelVisionLabs.Collections.Trees.Immutable
             {
                 Node root = _root;
                 root.Freeze();
-                return new ImmutableTreeList<T>(root);
+                if (root == _immutableList._root)
+                    return _immutableList;
+
+                _immutableList = new ImmutableTreeList<T>(root);
+                return _immutableList;
             }
 
             public bool TrueForAll(Predicate<T> match)

--- a/TunnelVisionLabs.Collections.Trees.Test/Immutable/ImmutableTreeListBuilderTest.cs
+++ b/TunnelVisionLabs.Collections.Trees.Test/Immutable/ImmutableTreeListBuilderTest.cs
@@ -1141,6 +1141,24 @@ namespace TunnelVisionLabs.Collections.Trees.Test.Immutable
         }
 
         [Fact]
+        public void TestToImmutable()
+        {
+            int value = Generator.GetInt32();
+
+            ImmutableTreeList<int>.Builder list = ImmutableTreeList.CreateBuilder<int>();
+            Assert.Empty(list);
+            Assert.Same(ImmutableTreeList<int>.Empty, list.ToImmutable());
+
+            list.Add(value);
+            Assert.Equal(new[] { value }, list.ToImmutable());
+            Assert.Same(list.ToImmutable(), list.ToImmutable());
+
+            list.Add(value);
+            Assert.Equal(new[] { value, value }, list.ToImmutable());
+            Assert.Same(list.ToImmutable(), list.ToImmutable());
+        }
+
+        [Fact]
         public void TestTrueForAll()
         {
             var list = ImmutableTreeList.CreateBuilder<int>();


### PR DESCRIPTION
The `ToImmutable()` should return the same list for subsequent calls when no changes have occurred in the builder.