### PR TITLE
Optimize FixedArray8<T> indexer

### DIFF
--- a/TunnelVisionLabs.Collections.Trees/Immutable/FixedArray8`1.cs
+++ b/TunnelVisionLabs.Collections.Trees/Immutable/FixedArray8`1.cs
@@ -7,10 +7,14 @@ namespace TunnelVisionLabs.Collections.Trees.Immutable
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Runtime.CompilerServices;
+    using System.Runtime.InteropServices;
 
+    [StructLayout(LayoutKind.Sequential)]
     internal struct FixedArray8<T>
     {
         private T _item0;
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable CS0169 // The field 'name' is never used
         private T _item1;
         private T _item2;
         private T _item3;
@@ -18,83 +22,29 @@ namespace TunnelVisionLabs.Collections.Trees.Immutable
         private T _item5;
         private T _item6;
         private T _item7;
+#pragma warning restore CS0169 // The field 'name' is never used
+#pragma warning restore IDE0044 // Add readonly modifier
 
         public int Length => 8;
 
         public T this[int index]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                switch (index)
-                {
-                case 0:
-                    return _item0;
+                if ((uint)index >= 8)
+                    ThrowHelper.ThrowIndexOutOfRangeException();
 
-                case 1:
-                    return _item1;
-
-                case 2:
-                    return _item2;
-
-                case 3:
-                    return _item3;
-
-                case 4:
-                    return _item4;
-
-                case 5:
-                    return _item5;
-
-                case 6:
-                    return _item6;
-
-                case 7:
-                    return _item7;
-
-                default:
-                    throw new IndexOutOfRangeException();
-                }
+                return Unsafe.Add(ref _item0, index);
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
-                switch (index)
-                {
-                case 0:
-                    _item0 = value;
-                    break;
+                if ((uint)index >= 8)
+                    ThrowHelper.ThrowIndexOutOfRangeException();
 
-                case 1:
-                    _item1 = value;
-                    break;
-
-                case 2:
-                    _item2 = value;
-                    break;
-
-                case 3:
-                    _item3 = value;
-                    break;
-
-                case 4:
-                    _item4 = value;
-                    break;
-
-                case 5:
-                    _item5 = value;
-                    break;
-
-                case 6:
-                    _item6 = value;
-                    break;
-
-                case 7:
-                    _item7 = value;
-                    break;
-
-                default:
-                    throw new IndexOutOfRangeException();
-                }
+                Unsafe.Add(ref _item0, index) = value;
             }
         }
 

--- a/TunnelVisionLabs.Collections.Trees/ThrowHelper.cs
+++ b/TunnelVisionLabs.Collections.Trees/ThrowHelper.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace TunnelVisionLabs.Collections.Trees
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+
+    internal static class ThrowHelper
+    {
+        [DoesNotReturn]
+        internal static void ThrowIndexOutOfRangeException()
+        {
+            throw new IndexOutOfRangeException();
+        }
+    }
+}

--- a/TunnelVisionLabs.Collections.Trees/TunnelVisionLabs.Collections.Trees.csproj
+++ b/TunnelVisionLabs.Collections.Trees/TunnelVisionLabs.Collections.Trees.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Use `Unsafe.Add` for direct access
* Apply `MethodImplOptions.AggressiveInlining`
* Use throw helper

### Benchmark using `AddRange`

0. Baseline
1. Switch to `Unsafe.Add` in indexer
2. Add AggressiveInlining and throw helper

|               Method   |    Count |               Mean |              Error |             StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|----------------------- |--------- |-------------------:|-------------------:|-------------------:|------:|--------:|------------:|------------:|------------:|--------------------:|
|     ImmutableList<T>   |       10 |           734.9 ns |         393.880 ns |         21.5899 ns |  1.00 |    0.00 |      1.0605 |           - |           - |               834 B |
|    ImmutableArray<T>   |       10 |           308.4 ns |         220.845 ns |         12.1052 ns |  0.42 |    0.02 |      0.3772 |           - |           - |               297 B |
| ImmutableTreeList<T> 0 |       10 |           429.7 ns |         148.300 ns |          8.1290 ns |  0.60 |    0.02 |      0.5097 |           - |           - |               401 B |
| ImmutableTreeList<T> 1 |       10 |           288.7 ns |           4.789 ns |          0.2625 ns |  0.39 |    0.01 |      0.5097 |           - |           - |               401 B |
| ImmutableTreeList<T> 2 |       10 |           264.2 ns |          14.590 ns |          0.7998 ns |  0.37 |    0.01 |      0.5097 |           - |           - |               401 B |
|                        |          |                    |                    |                    |       |         |             |             |             |                     |
|     ImmutableList<T>   |     1000 |        32,815.0 ns |      39,520.030 ns |      2,166.2262 ns |  1.00 |    0.00 |     52.0630 |      8.6670 |           - |             60777 B |
|    ImmutableArray<T>   |     1000 |         6,758.1 ns |         309.823 ns |         16.9824 ns |  0.21 |    0.01 |     15.8691 |           - |           - |             12508 B |
| ImmutableTreeList<T> 0 |     1000 |        58,769.1 ns |      11,984.860 ns |        656.9300 ns |  1.83 |    0.10 |     14.8926 |           - |           - |             11724 B |
| ImmutableTreeList<T> 1 |     1000 |        38,737.7 ns |      11,470.392 ns |        628.7309 ns |  1.18 |    0.06 |     14.8926 |           - |           - |             11724 B |
| ImmutableTreeList<T> 2 |     1000 |        33,213.6 ns |       8,506.380 ns |        466.2632 ns |  1.02 |    0.07 |     14.8926 |           - |           - |             11724 B |
|                        |          |                    |                    |                    |       |         |             |             |             |                     |
|     ImmutableList<T>   |   100000 |     8,297,334.1 ns |   1,368,147.755 ns |     74,992.7951 ns |  1.00 |    0.00 |   1000.0000 |    609.3750 |    390.6250 |           6265724 B |
|    ImmutableArray<T>   |   100000 |       718,363.3 ns |     533,829.695 ns |     29,261.0069 ns |  0.09 |    0.00 |    399.4141 |    399.4141 |    399.4141 |           1452144 B |
| ImmutableTreeList<T> 0 |   100000 |    10,210,487.3 ns |   2,561,610.010 ns |    140,410.4880 ns |  1.21 |    0.08 |    187.5000 |     93.7500 |           - |           1123347 B |
| ImmutableTreeList<T> 1 |   100000 |     6,470,338.1 ns |   1,207,622.535 ns |     66,193.8661 ns |  0.78 |    0.01 |    179.6875 |     85.9375 |           - |           1123357 B |
| ImmutableTreeList<T> 2 |   100000 |     5,601,348.3 ns |     591,887.890 ns |     32,443.3726 ns |  0.63 |    0.06 |    179.6875 |     85.9375 |           - |           1123357 B |
|                        |          |                    |                    |                    |       |         |             |             |             |                     |
|     ImmutableList<T>   | 10000000 | 1,420,494,400.0 ns | 188,008,648.079 ns | 10,305,388.4080 ns |  1.00 |    0.00 |  78000.0000 |  28000.0000 |   1000.0000 |         655634848 B |
|    ImmutableArray<T>   | 10000000 |   108,571,620.0 ns |  81,204,808.000 ns |  4,451,109.5398 ns |  0.08 |    0.00 |   1400.0000 |   1400.0000 |   1400.0000 |         174226376 B |
| ImmutableTreeList<T> 0 | 10000000 | 1,545,463,533.3 ns | 160,400,634.270 ns |  8,792,100.0120 ns |  1.09 |    0.01 |  18000.0000 |   6000.0000 |           - |         112176752 B |
| ImmutableTreeList<T> 1 | 10000000 |   986,178,366.7 ns | 336,117,471.221 ns | 18,423,732.7752 ns |  0.69 |    0.01 |  18000.0000 |   6000.0000 |           - |         112176752 B |
| ImmutableTreeList<T> 2 | 10000000 |   867,280,133.3 ns | 155,179,711.470 ns |  8,505,923.6161 ns |  0.61 |    0.01 |  18000.0000 |   6000.0000 |           - |         112176752 B |
